### PR TITLE
Enable Claude to make code modifications via PR comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,21 +21,32 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "claude-bot@users.noreply.github.com"
+          git config --local user.name "Claude Bot"
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allow_file_modifications: true
+          auto_commit: true
+          commit_message_prefix: "Claude: "
 
   # Note: GitHub Copilot code review is available as a manual feature in the GitHub UI
   # Automated code review via GitHub Actions is not currently supported by GitHub Copilot


### PR DESCRIPTION
## Summary
- Upgrades Claude GitHub workflow from read-only to write permissions
- Enables Claude to make file modifications, commit, and push changes in response to PR comments
- Adds proper Git configuration for automated commits

## Changes
- Updated permissions to `write` for contents, pull-requests, and issues
- Modified checkout to use full Git history and PR branch reference
- Added Git user configuration for Claude Bot commits
- Added Claude action parameters: `allow_file_modifications`, `auto_commit`, `github_token`
- Commits will be prefixed with "Claude: " for clear attribution

## Usage
After merging, team members can:
1. Mention `@claude` in PR comments with specific requests
2. Claude will analyze the code and make requested changes
3. Changes are automatically committed and pushed to the PR branch
4. Example: "@claude fix the typo on line 42" → Claude makes the fix and commits

## Test Plan
- [ ] Verify workflow has proper permissions
- [ ] Test with a sample PR comment mentioning @claude
- [ ] Confirm Claude can make file modifications
- [ ] Validate commits are properly attributed to Claude Bot

🤖 Generated with [Claude Code](https://claude.ai/code)